### PR TITLE
Fix bug regarding the setFullScale function on the H3LIS331DL & LIS3DH

### DIFF
--- a/src/SparkFun_LIS331.cpp
+++ b/src/SparkFun_LIS331.cpp
@@ -253,7 +253,7 @@ void LIS331::setFullScale(fs_range range)
   uint8_t data; 
   LIS331_read(CTRL_REG4, &data, 1);
   data &= ~0xcf;
-  data |= range<<5;
+  data |= range<<4;
   LIS331_write(CTRL_REG4, &data, 1);
 }
 


### PR DESCRIPTION
Previous behaviour incorrectly set the ranges.

Attempting to set a 100g range would actually set the data to come out
in little endian order.

Attempting to set a 200g range would actually set the data to come out
in little endian order AND put the FS1/FS0 bits into an invalid state
(10)

Attempting to set a 400g range would actually set the data to come out
in big endian order AND put the FS1/FS0 bits into an invalid state (10).

Now we correctly set the range bits and leave little / big endian alone.