### PR TITLE
Update SparkFun_LIS331.h

### DIFF
--- a/src/SparkFun_LIS331.h
+++ b/src/SparkFun_LIS331.h
@@ -35,7 +35,7 @@ class LIS331
                 LOW_POWER_2HZ, LOW_POWER_5HZ, LOW_POWER_10HZ} power_mode;
   typedef enum {DR_50HZ, DR_100HZ, DR_400HZ, DR_1000HZ} data_rate;
   typedef enum {HPC_8, HPC_16, HPC_32, HPC_64} high_pass_cutoff_freq_cfg;
-  typedef enum {PUSH_PULL, OPEN_DRAIN} pp_od;
+  typedef enum {PUSH_PULL, OPEN_DRAIN_LIS331} pp_od;
   typedef enum {INT_SRC, INT1_2_SRC, DRDY, BOOT} int_sig_src;
   typedef enum {LOW_RANGE, MED_RANGE, NO_RANGE, HIGH_RANGE} fs_range;
   typedef enum {X_AXIS, Y_AXIS, Z_AXIS} int_axis;


### PR DESCRIPTION
Changed OPEN_DRAIN variable to OPEN_DRAIN_LIS331 to make it compatible with ESP32-core in arduino IDE Will propose a matching change on cpp file as well